### PR TITLE
Fixing tensorflow protobuf error

### DIFF
--- a/install/tensorflow.sh
+++ b/install/tensorflow.sh
@@ -41,8 +41,7 @@ popd
 
 # install tensorflow
 pushd /tensorflow
-git clone --recurse-submodules https://github.com/tensorflow/tensorflow .
-git checkout $TENSORFLOW_VERSION
+git clone -b $TENSORFLOW_VERSION --recurse-submodules https://github.com/tensorflow/tensorflow .
 GCC_HOST_COMPILER_PATH=/usr/bin/gcc PYTHON_BIN_PATH=/usr/local/bin/python \
     CUDA_TOOLKIT_PATH=/usr/local/cuda CUDNN_INSTALL_PATH=/usr/local/cuda \
     TF_NEED_CUDA=1 TF_CUDA_VERSION=7.5 TF_CUDNN_VERSION=4 \


### PR DESCRIPTION
After tensorflow-0.9 release, creating tensorflow image is failing with following error. To fix it, we might have to branch directly instead of clone and checkout. https://www.tensorflow.org/versions/r0.9/get_started/os_setup.html#installing_from_sources

amazon-ebs: ____Loading package: tensorflow/tools/pip_package
    amazon-ebs: ____Loading...
    amazon-ebs: ____Loading package: @bazel_tools//tools/objc
    amazon-ebs: ____Loading package: third_party/gpus/crosstool
    amazon-ebs: ____Loading package: tensorflow/models/image/mnist
    amazon-ebs: ERROR: /tensorflow/tensorflow/tools/pip_package/BUILD:23:1: error loading package 'tensorflow/core': Extension file not found. Unable to load package for '//google/protobuf:protobuf.bzl': BUILD file not found on package path and referenced by '//tensorflow/tools/pip_package:build_pip_package'.
    amazon-ebs: ERROR: Loading failed; build aborted.
    amazon-ebs: ____Elapsed time: 3.835s
==> amazon-ebs: Terminating the source AWS instance...
